### PR TITLE
Adds Whiterun Commander armor

### DIFF
--- a/code/TES13/items/armor/lightarmor.dm
+++ b/code/TES13/items/armor/lightarmor.dm
@@ -72,5 +72,11 @@
 	desc = "Standard Whiterun guard armor reinforced with metal and extra leather, worn by the Captain of the Guard."
 	icon_state = "whiteguard"
 	item_state = "whiteguard"
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 0, "energy" = 45, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 0)
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 0, "energy" = 40, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 35, "acid" = 0)
 
+/obj/item/clothing/suit/armor/light/leather/whiteguard/commander
+	name = "whiterun guard commander armor"
+	desc = "Heavily reinforced Whiterun guard armor worn by the Commander of the Guard."
+	icon_state = "whiteguard"
+	item_state = "whiteguard"
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 0, "energy" = 45, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 0)

--- a/code/TES13/items/armor/lightboots.dm
+++ b/code/TES13/items/armor/lightboots.dm
@@ -75,4 +75,11 @@
 	desc = "Whiterun guard boots reinforced with metal, the boots of choice for the Captain of the Guard."
 	icon_state = "cuirassboots"
 	item_state = "cuirassboots"
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 0, "energy" = 40, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 35, "acid" = 0)
+
+/obj/item/clothing/shoes/combat/light/leather/whiteguard/commander
+	name = "whiterun guard commander boots"
+	desc = "Fortified Whiterun guard boots, incredibly durable and used by the Guard Commander."
+	icon_state = "cuirassboots"
+	item_state = "cuirassboots"
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 0, "energy" = 45, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 0)

--- a/code/TES13/items/armor/lightgloves.dm
+++ b/code/TES13/items/armor/lightgloves.dm
@@ -73,4 +73,11 @@
 	desc = "Whiterun Guard gloves reinforced with metal and more leather padding, typically worn by the Guard Captain."
 	icon_state = "cuirassgloves"
 	item_state = "cuirassgloves"
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 0, "energy" = 40, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 35, "acid" = 0)
+
+/obj/item/clothing/gloves/combat/light/leather/whiteguard/commander
+	name = "whiterun guard commander gloves"
+	desc = "Durable Whiterun guard gloves, fitted with strong reinforcements. Worn by the Guard Commander."
+	icon_state = "cuirassgloves"
+	item_state = "cuirassgloves"
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 0, "energy" = 45, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 0)

--- a/code/TES13/items/armor/lighthelmets.dm
+++ b/code/TES13/items/armor/lighthelmets.dm
@@ -79,4 +79,11 @@
 	desc = "A Whiterun guard helmet reinforced with metal and leather, worn by the Guard Captain."
 	icon_state = "whiteguard"
 	item_state = "whiteguard"
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 0, "energy" = 40, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 35, "acid" = 0)
+
+/obj/item/clothing/head/helmet/light/leather/whiteguard/commander
+	name = "whiterun guard commander helmet"
+	desc = "A heavily reinforced and strong Whiterun guard helmet. Reserved for the Guard Commander."
+	icon_state = "whiteguard"
+	item_state = "whiteguard"
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 0,"energy" = 45, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 40, "acid" = 0)


### PR DESCRIPTION
## About The Pull Request

Title, also slightly nerfs Captain armor to reflect that they are not the highest rank anymore.

## Why It's Good For The Game

Adding in Whiterun Guard Commander to make it so one Captain is not handling an entire guard force of 15+ people.

## Changelog
:cl:

add: Adds Whiterun Commander armor

tweak: Nerfs the armor values of Captain armor by 5.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
