### PR TITLE
Restoration 1.0

### DIFF
--- a/code/TES13/magic/magicka.dm
+++ b/code/TES13/magic/magicka.dm
@@ -13,6 +13,7 @@
 	holder_var_amount = 20 //base magicka cost of default spell (overridden by every spell, ever). negative values = spell regenerates magicka.
 	holder_var_name = "magicka" //for displaying
 
+	human_req = TRUE
 	clothes_req = FALSE //see if it requires magic clothes (note: these give +magicka regen anyway)
 	nonabstract_req = FALSE //spell can only be cast by mobs that are physical entities
 	stat_allowed = FALSE //see if it requires being conscious/alive, need to set to 1 for ghostpells

--- a/code/TES13/magic/restoration.dm
+++ b/code/TES13/magic/restoration.dm
@@ -1,0 +1,96 @@
+// TES13 restoration spells!
+
+/obj/effect/proc_holder/spell/magicka/channelled/inhand/healinghands
+	name = "Healing Hands"
+	desc = "Conduct restorative energy through your hands, allowing you to heal anyone near you (or yourself) with a sustained channel of magic."
+	human_req = TRUE
+	holder_var_amount = 0
+	drain = 10
+	school = "restoration"
+	sound = 'sound/magic/staff_healing.ogg'
+	action_icon_state = "bonechill" //placeholder
+	inhand_type = /obj/item/gun/medbeam/healinghands
+
+/datum/spellbook_entry/healinghands
+	name = "Healing Hands"
+	spell_type = /obj/effect/proc_holder/spell/magicka/channelled/inhand/healinghands
+
+/obj/item/gun/medbeam/healinghands
+	name = "healing hand"
+	desc = "A hand charged with restorative energy."
+	icon = 'icons/obj/items_and_weapons.dmi'
+	lefthand_file = 'icons/mob/inhands/misc/touchspell_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/touchspell_righthand.dmi'
+	icon_state = "zapper"
+	item_state = "zapper"
+	item_flags = ABSTRACT | DROPDEL
+	w_class = WEIGHT_CLASS_HUGE
+	force = 0
+	throwforce = 0
+	throw_range = 0
+	throw_speed = 0
+	healamt = 2.5 //approximately 10 brute/burn and 2.5 oxy/tox per Life().
+	max_range = 4
+	pin = /obj/item/firing_pin/magic
+
+/obj/item/gun/medbeam/healinghands/Initialize()
+	. = ..()
+	add_trait(ABSTRACT_ITEM_TRAIT)
+
+/obj/item/gun/medbeam/healinghands/handle_suicide() //Stops people trying to commit suicide to heal themselves
+	return
+
+/obj/item/gun/medbeam/healinghands/dropped(mob/user) //if you drop it, cancel the spell.
+	if(user.mind)
+		if(user.mind.spell_list)
+			for(var/obj/effect/proc_holder/spell/magicka/channelled/inhand/healinghands/spell in user.mind.spell_list)
+				if(spell.channel == 1):
+					spell.channel = 0
+
+/obj/effect/proc_holder/spell/magicka/channelled/inhand/grandhealing
+	name = "Grand Healing"
+	desc = "Unleash a burst of restorative magicka, healing yourself and everyone near you of even the most serious injuries."
+
+	holder_var_amount = 30
+	drain = 30
+	school = "restoration"
+	sound = 'sound/magic/staff_healing.ogg'
+	action_icon_state = "bonechill" //placeholder
+	inhand_type = /obj/item/melee/spellholder/grandhealing
+
+/datum/spellbook_entry/grandhealing
+	name = "Grand Healing"
+	spell_type = /obj/effect/proc_holder/spell/magicka/channelled/inhand/grandhealing
+
+/obj/item/melee/spellholder/grandhealing
+	name = "\improper grand healing"
+	desc = "An overwhelmingly powerful restoration spell. You're not sure you can contain this much magicka for long."
+	linkedspell = /obj/effect/proc_holder/spell/magicka/channelled/inhand/grandhealing
+
+//WIP - we want this to check for living mobs within 8 tiles and heal. won't bring back the dead, but will do everything else.
+
+/obj/item/melee/spellholder/grandhealing/attack_self(mob/living/user)
+	user.visible_message("<span class='warning'>[user] begins to cast a powerful spell!</span>", "<span class='notice'>You begin to cast a powerful spell!</span>")
+	if(do_after(user, 30, target=user)) //3 seconds
+		to_chat(user, "Debug: spell success!")
+		user.reagents.remove_all_type(/datum/reagent/toxin, 100, 0, 1)
+		user.setCloneLoss(0, 0)
+		user.setOxyLoss(0, 0)
+		user.radiation = 0
+		user.heal_bodypart_damage(100,100)
+		user.adjustToxLoss(-5, 0, TRUE)
+		user.hallucination = 0
+		user.setBrainLoss(0)
+		user.set_blurriness(0)
+		user.set_blindness(0)
+		user.SetKnockdown(0, FALSE)
+		user.SetStun(0, FALSE)
+		user.SetUnconscious(0, FALSE)
+		user.SetParalyzed(0, FALSE)
+		user.SetImmobilized(0, FALSE)
+		user.SetSleeping(0, 0)
+		qdel(src)
+
+	else
+		user.visible_message("<span class='warning'>[user] loses focus on the spell!</span>", "<span class='notice'>You lose focus on the spell!</span>")
+		qdel(src)

--- a/code/TES13/magic/spelltypes.dm
+++ b/code/TES13/magic/spelltypes.dm
@@ -82,3 +82,106 @@
 	name = "Lesser Heal Over Time"
 	spell_type = /obj/effect/proc_holder/spell/magicka/channelled/basic_heal_over_time
 */
+
+
+/obj/effect/proc_holder/spell/magicka/channelled/inhand //for channelled spells that give you an in-hand object for the duration (e.g. healing hands, conjure sword)
+	var/inhand_type = /obj/item/gun/medbeam/healinghands //what does it put in your hand?
+
+/obj/effect/proc_holder/spell/magicka/channelled/inhand/cast(mob/living/carbon/human/user)
+	if(user.magicka == 0) //no magicka (or antimagic, or dead...)? can't cast
+		return 0
+	else if(channel == 0)
+		channel = 1
+		to_chat(user, "<span class='warning'>You begin channelling magicka into your hand!</span>")
+	else
+		channel = 0
+		to_chat(user, "<span class='warning'>You stop channelling magicka into your hand!</span>")
+		user.magicka += holder_var_amount //refund any extra magicka you used from casting the cancel
+		for(var/obj/item/H in user.held_items) //delete the healing hands
+			if(istype(H, inhand_type))
+				qdel(H)
+
+/obj/effect/proc_holder/spell/magicka/channelled/inhand/effect(mob/living/carbon/user) //only checked while active.
+	for(var/obj/item/H in user.held_items) //if you already have one, don't give another
+		if(istype(H, inhand_type))
+			return
+	var/obj/item/I = new inhand_type(user)
+	if(user.can_equip(I, SLOT_HANDS))
+		user.put_in_hands(I)
+	else
+		if (user.get_num_arms() <= 0)
+			to_chat(user, "<span class='warning'>You dont have any usable hands!</span>")
+			qdel(I)
+		else
+			to_chat(user, "<span class='warning'>Your hands are full!</span>")
+			qdel(I)
+
+/obj/effect/proc_holder/spell/magicka/channelled/inhand/disable(mob/living/carbon/user) //if force disable
+	channel = 0
+	for(var/obj/item/H in user.held_items) //delete the inhand_type
+		if(istype(H, inhand_type))
+			qdel(H)
+
+/*/obj/item/gun/medbeam/healinghands
+	name = "healing hand"
+	desc = "A hand charged with restorative energy."
+	icon = 'icons/obj/items_and_weapons.dmi'
+	lefthand_file = 'icons/mob/inhands/misc/touchspell_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/touchspell_righthand.dmi'
+	icon_state = "zapper"
+	item_state = "zapper"
+	item_flags = ABSTRACT | DROPDEL
+	w_class = WEIGHT_CLASS_HUGE
+	force = 0
+	throwforce = 0
+	throw_range = 0
+	throw_speed = 0
+	healamt = 5 //heals 5 brute/burn and [5/4] oxy/tox per tick.
+	max_range = 4
+	pin = /obj/item/firing_pin/magic
+
+/obj/item/gun/medbeam/healinghands/Initialize()
+	. = ..()
+	add_trait(ABSTRACT_ITEM_TRAIT)
+
+/obj/item/gun/medbeam/healinghands/handle_suicide() //Stops people trying to commit suicide to heal themselves
+	return
+
+/obj/item/gun/medbeam/healinghands/dropped(mob/user) //if you drop it, cancel the spell.
+	if(user.mind)
+		if(user.mind.spell_list)
+			for(var/obj/effect/proc_holder/spell/magicka/channelled/inhand/healinghands/spell in user.mind.spell_list)
+				if(spell.channel == 1):
+					spell.channel = 0
+
+*/
+
+/obj/item/melee/spellholder
+	name = "\improper spellholder"
+	desc = "You shouldn't be seeing this!"
+	icon = 'icons/obj/items_and_weapons.dmi'
+	lefthand_file = 'icons/mob/inhands/misc/touchspell_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/touchspell_righthand.dmi'
+	icon = 'icons/obj/items_and_weapons.dmi'
+	lefthand_file = 'icons/mob/inhands/misc/touchspell_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/touchspell_righthand.dmi'
+	icon_state = "zapper"
+	item_state = "zapper"
+	item_flags = ABSTRACT | DROPDEL
+	w_class = WEIGHT_CLASS_HUGE
+	force = 0
+	throwforce = 0
+	throw_range = 0
+	throw_speed = 0
+	var/obj/effect/proc_holder/spell/magicka/channelled/inhand/linkedspell = null
+
+/obj/item/melee/spellholder/Initialize()
+	. = ..()
+	add_trait(ABSTRACT_ITEM_TRAIT)
+
+/obj/item/melee/spellholder/dropped(mob/user) //if you drop it, cancel the spell.
+	if(user.mind)
+		if(user.mind.spell_list)
+			for(linkedspell in user.mind.spell_list)
+				if(linkedspell.channel == 1)
+					linkedspell.channel = 0

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -239,7 +239,7 @@
 	AddComponent(/datum/component/butchering, 100, 80, 0 , hitsound) //axes are not known for being precision butchering tools
 
 /obj/item/twohanded/fireaxe/update_icon()  //Currently only here to fuck with the on-mob icons.
-	icon_state = "fireaxe[wielded]"
+	icon_state = "[initial(icon_state)][wielded]"
 	return
 
 /obj/item/twohanded/fireaxe/suicide_act(mob/user)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -501,11 +501,11 @@
 		return
 
 	if(user == target)
-		target.visible_message("<span class='warning'>[user] sticks [src] in [user.p_their()] mouth, ready to pull the trigger...</span>", \
-			"<span class='userdanger'>You stick [src] in your mouth, ready to pull the trigger...</span>")
+		target.visible_message("<span class='warning'>[user] aims [src] at [user.p_their()] head, ready to shoot...</span>", \
+			"<span class='userdanger'>You aim [src] at your head, ready to shoot...</span>")
 	else
-		target.visible_message("<span class='warning'>[user] points [src] at [target]'s head, ready to pull the trigger...</span>", \
-			"<span class='userdanger'>[user] points [src] at your head, ready to pull the trigger...</span>")
+		target.visible_message("<span class='warning'>[user] points [src] at [target]'s head, ready to shoot...</span>", \
+			"<span class='userdanger'>[user] points [src] at your head, ready to shoot...</span>")
 
 	semicd = TRUE
 
@@ -520,7 +520,7 @@
 
 	semicd = FALSE
 
-	target.visible_message("<span class='warning'>[user] pulls the trigger!</span>", "<span class='userdanger'>[(user == target) ? "You pull" : "[user] pulls"] the trigger!</span>")
+	target.visible_message("<span class='warning'>[user] shoots!</span>", "<span class='userdanger'>[(user == target) ? "You shoot" : "[user] shoots"]!</span>")
 
 	if(chambered && chambered.BB)
 		chambered.BB.damage *= 5

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -13,6 +13,7 @@
 	var/active = 0
 	var/datum/beam/current_beam = null
 	var/mounted = 0 //Denotes if this is a handheld or mounted version
+	var/healamt = 4 //how much brute/burn it heals per tick
 
 	weapon_weight = WEAPON_MEDIUM
 
@@ -76,7 +77,7 @@
 	if(get_dist(source, current_target)>max_range || !los_check(source, current_target))
 		LoseTarget()
 		if(isliving(source))
-			to_chat(source, "<span class='warning'>You lose control of the beam!</span>")
+			to_chat(source, "<span class='warning'>Your target is out of range!</span>")
 		return
 
 	if(current_target)
@@ -102,9 +103,7 @@
 				return 0
 		for(var/obj/effect/ebeam/medical/B in turf)// Don't cross the str-beams!
 			if(B.owner.origin != current_beam.origin)
-				explosion(B.loc,0,3,5,8)
-				qdel(dummy)
-				return 0
+				return 1
 	qdel(dummy)
 	return 1
 
@@ -114,17 +113,17 @@
 /obj/item/gun/medbeam/proc/on_beam_tick(var/mob/living/target)
 	if(target.health != target.maxHealth)
 		new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
-	target.adjustBruteLoss(-4)
-	target.adjustFireLoss(-4)
-	target.adjustToxLoss(-1)
-	target.adjustOxyLoss(-1)
+	target.adjustBruteLoss(-healamt*4)
+	target.adjustFireLoss(-healamt*4)
+	target.adjustToxLoss(-healamt)
+	target.adjustOxyLoss(-healamt)
 	return
 
 /obj/item/gun/medbeam/proc/on_beam_release(var/mob/living/target)
 	return
 
 /obj/effect/ebeam/medical
-	name = "medical beam"
+	name = "healing beam"
 
 //////////////////////////////Mech Version///////////////////////////////
 /obj/item/gun/medbeam/mech

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2819,6 +2819,7 @@
 #include "code\TES13\items\weapons\onehanded.dm"
 #include "code\TES13\items\weapons\twohanded.dm"
 #include "code\TES13\magic\magicka.dm"
+#include "code\TES13\magic\restoration.dm"
 #include "code\TES13\magic\spelltypes.dm"
 #include "code\TES13\smithing\ingots.dm"
 #include "interface\interface.dm"


### PR DESCRIPTION
## About The Pull Request

WIP, but should be merged anyway so we can get the framework in place for other spells.
Healing Hands: low magicka cost, channelled inhand- allows the user to shoot healbeams from their hands, which connect to a target and heal them. You can't use this on yourself.
Grand Healing (WIP): channeled inhand, high magicka cost, takes a few seconds of standing still to cast. Pretty much fully heals everyone you can see who isn't dead. Master-level spells, yo.

## Why It's Good For The Game

Well, for starters, channelled inhand is now a valid type of spell- cast it and it puts something in your hand until you cancel the spell (by dropping it, encountering an antimagic effect, running out of magicka, etc etc).

Also fixes fireaxe child sprite pathing so we can use it for battleaxes, and makes crossbows not look like guns when you aim them at someone's head.

Documentation provided for folks working on other schools of magic- channelled inhand very useful for Destruction's Flames, Frostbite, etc. Note that magicka drained while the item is merely in the hand, not just actively being used- so drop the spell if you're not using it!

Todo: possibly use the debug selfheal(-over-time) spells too? More spell variety + code already exists. Also Grand Healing, and have targeted healing be a thing (see barnyard curse) for lesser/advanced heal. Full restore spell for curing broken bones when we get around to adding those.

## Changelog
:cl:
add: Restoration magic! Two spells currently (WIP) - one that works like a short-range medbeam, and one that heals everyone near the caster for a huge amount, but takes time to cast.
/:cl: